### PR TITLE
Refactor build-release workflow for improved handling and syncing

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -173,7 +173,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          upx --best --lzma sing-box
+          sudo apt-get update
+          sudo apt-get install -y upx-ucl
+          upx-ucl --best --lzma sing-box
           ls -lh sing-box
           mkdir -p dist
           cp sing-box "dist/sing-box-${VERSION}-linux-${{ matrix.arch }}.upx"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -199,7 +199,7 @@ jobs:
             echo '```'
           } > body.md
 
-      - name: 发布 Release（tag: ${{ needs.prepare.outputs.version }}）
+      - name: "发布 Release（tag: ${{ needs.prepare.outputs.version }}）"
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,10 +27,13 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
       tags: ${{ steps.tags.outputs.tags }}
     steps:
-      - name: 检出仓库（拉取全部 tag）
+      # 注意：go.mod 用 replace 把 gvisor 指向 ./submodules/gvisor，
+      # 必须拉取 submodule，否则编译时报 submodules/gvisor/go.mod 不存在
+      - name: 检出仓库（拉取全部 tag 与 submodule）
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          submodules: recursive
 
       - name: 解析版本号并切换到对应 tag
         id: meta
@@ -54,6 +57,8 @@ jobs:
           echo "本次构建版本: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           git checkout --detach "refs/tags/$VERSION"
+          # checkout 换了 ref 之后，submodule 记录的提交可能随之变化，需要同步
+          git submodule update --init --recursive
 
       - name: 从 Makefile.lx 解析 LX_TAGS 并过滤保留 6 个标签
         id: tags
@@ -112,13 +117,14 @@ jobs:
       VERSION: ${{ needs.prepare.outputs.version }}
       TAGS: ${{ needs.prepare.outputs.tags }}
     steps:
-      - name: 检出 tag ${{ needs.prepare.outputs.version }}
+      - name: 检出 tag ${{ needs.prepare.outputs.version }}（含 submodule）
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.version }}
           fetch-depth: 0
+          submodules: recursive
 
-      - name: 安装 Go
+      - name: 安装 Go（版本读取自 go.mod）
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
@@ -141,7 +147,7 @@ jobs:
             -o sing-box ./cmd/sing-box
           ls -lh sing-box
 
-      - name: 打包普通 tar.gz
+      - name: 打包普通 tar.gz（内部仅含 sing-box 二进制）
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -62,16 +62,23 @@ jobs:
           set -euo pipefail
           KEEP="with_quic with_utls with_clash_api with_xhttp badlinkname tfogo_checklinkname0"
 
-          # 优先用 make 本身展开 TAGS（可正确处理 := ?= += 及变量引用）
+          # 若检出的 tag 上没有 Makefile.lx，回退使用 lx 分支上的版本
+          if [ ! -f Makefile.lx ]; then
+            echo "::warning::当前 tag 上不存在 Makefile.lx，改用 lx 分支的 Makefile.lx"
+            git show origin/lx:Makefile.lx > Makefile.lx
+          fi
+
+          # 优先用 make 本身展开 TAGS（兼容 := ?= += 及变量引用）
           RAW=$(make -f Makefile.lx --no-print-directory -s \
                 --eval='print-tags: ; @echo $(TAGS)' print-tags 2>/dev/null || true)
 
-          # 回退：用 grep/sed 直接解析 TAGS 定义行
+          # 回退：用 grep/sed 解析 TAGS 定义行（兼容 export/override 前缀）
+          # 注意结尾的 || true：防止 grep 未命中时管道非零退出被 set -e 终止
           if [ -z "${RAW// /}" ]; then
-            RAW=$(grep -E '^[[:space:]]*TAGS[[:space:]]*[:?+]?=' Makefile.lx | head -n1 \
-                  | sed -E 's/^[[:space:]]*TAGS[[:space:]]*[:?+]?=[[:space:]]*//')
+            RAW=$(grep -E '^[[:space:]]*(export[[:space:]]+)?(override[[:space:]]+)?TAGS[[:space:]]*[:?+]?=' Makefile.lx | head -n1 \
+                  | sed -E 's/^[[:space:]]*(export[[:space:]]+)?(override[[:space:]]+)?TAGS[[:space:]]*[:?+]?=[[:space:]]*//' || true)
           fi
-          echo "Makefile.lx 原始 TAGS: $RAW"
+          echo "Makefile.lx 原始 TAGS: '$RAW'"
 
           # 逗号/空格统一为换行后，按保留清单逐一过滤（保持清单顺序）
           TAGS=""
@@ -81,7 +88,8 @@ jobs:
             fi
           done
           if [ -z "$TAGS" ]; then
-            echo "::error::过滤后 TAGS 为空，请检查 Makefile.lx 中的 TAGS 定义"
+            echo "::error::过滤后 TAGS 为空。Makefile.lx 中 TAGS 相关行如下："
+            grep -n 'TAGS' Makefile.lx || true
             exit 1
           fi
           echo "过滤后 TAGS: $TAGS"
@@ -138,7 +146,7 @@ jobs:
             -o sing-box ./cmd/sing-box
           ls -lh sing-box
 
-      - name: 打包普通 tar.gz
+      - name: 打包普通 tar.gz（内部仅含 sing-box 二进制）
         shell: bash
         run: |
           set -euo pipefail
@@ -147,7 +155,7 @@ jobs:
           tar -czf "dist/sing-box-${VERSION}-linux-${{ matrix.arch }}.tar.gz" -C stage sing-box
           rm -f stage/sing-box
 
-      - name: UPX 压缩二进制
+      - name: UPX 压缩二进制并直接输出为发布文件
         if: matrix.upx
         shell: bash
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -147,7 +147,7 @@ jobs:
             -o sing-box ./cmd/sing-box
           ls -lh sing-box
 
-      - name: 打包普通 tar.gz（内部仅含 sing-box 二进制）
+      - name: 打包普通 tar.gz
         shell: bash
         run: |
           set -euo pipefail
@@ -156,7 +156,7 @@ jobs:
           tar -czf "dist/sing-box-${VERSION}-linux-${{ matrix.arch }}.tar.gz" -C stage sing-box
           rm -f stage/sing-box
 
-      - name: UPX 压缩二进制并直接输出为发布文件
+      - name: UPX 压缩二进制并输出为 .upx 发布文件
         if: matrix.upx
         shell: bash
         run: |
@@ -164,7 +164,7 @@ jobs:
           upx --best --lzma sing-box
           ls -lh sing-box
           mkdir -p dist
-          cp sing-box "dist/sing-box-${VERSION}-linux-${{ matrix.arch }}-upx"
+          cp sing-box "dist/sing-box-${VERSION}-linux-${{ matrix.arch }}.upx"
 
       - name: 上传构建产物到工件
         uses: actions/upload-artifact@v4
@@ -188,25 +188,18 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: 生成 SHA256SUMS 与 Release 正文
+      - name: 生成 Release 正文
         shell: bash
         working-directory: dist
         run: |
           set -euo pipefail
-          sha256sum sing-box-* | tee SHA256SUMS
-
           {
             echo "sing-box-lx ${{ needs.prepare.outputs.version }} 自动构建。"
             echo ""
             echo "- \`*.tar.gz\`：压缩包内含单个 \`sing-box\` 二进制"
-            echo "- \`*-upx\`：经 UPX (--best --lzma) 压缩的裸二进制，下载后 \`chmod +x\` 即可直接使用"
+            echo "- \`*.upx\`：经 UPX (--best --lzma) 压缩的裸二进制，下载后 \`chmod +x\` 即可直接使用"
             echo ""
             echo "构建标签：\`${{ needs.prepare.outputs.tags }}\`"
-            echo ""
-            echo "## 文件 SHA256"
-            echo '```'
-            cat SHA256SUMS
-            echo '```'
           } > body.md
 
       - name: "发布 Release（tag: ${{ needs.prepare.outputs.version }}）"
@@ -217,5 +210,4 @@ jobs:
           body_path: dist/body.md
           files: |
             dist/*.tar.gz
-            dist/sing-box-*-upx
-            dist/SHA256SUMS
+            dist/*.upx

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,6 +26,7 @@ jobs:
     outputs:
       version: ${{ steps.meta.outputs.version }}
       tags: ${{ steps.tags.outputs.tags }}
+      upstream: ${{ steps.meta.outputs.upstream }}
     steps:
       # 注意：go.mod 用 replace 把 gvisor 指向 ./submodules/gvisor，
       # 必须拉取 submodule，否则编译时报 submodules/gvisor/go.mod 不存在
@@ -59,6 +60,17 @@ jobs:
           git checkout --detach "refs/tags/$VERSION"
           # checkout 换了 ref 之后，submodule 记录的提交可能随之变化，需要同步
           git submodule update --init --recursive
+
+          # 推导对应的上游版本：优先读 upstream.version（Makefile.lx 的 pin 文件，
+          # 与 LX_VERSION 的构成保持一致），文件不存在则从 tag 名剥掉 -lx.N 后缀
+          if [ -f upstream.version ]; then
+            UPSTREAM_BASE=$(tr -d '[:space:]' < upstream.version)
+          else
+            UPSTREAM_BASE="${VERSION#v}"
+            UPSTREAM_BASE="${UPSTREAM_BASE%%-lx.*}"
+          fi
+          echo "上游基线版本: $UPSTREAM_BASE"
+          echo "upstream=$UPSTREAM_BASE" >> "$GITHUB_OUTPUT"
 
       - name: 从 Makefile.lx 解析 LX_TAGS 并过滤保留 6 个标签
         id: tags
@@ -195,6 +207,8 @@ jobs:
           set -euo pipefail
           {
             echo "sing-box-lx ${{ needs.prepare.outputs.version }} 自动构建。"
+            echo ""
+            echo "基于上游 [SagerNet/sing-box v${{ needs.prepare.outputs.upstream }}](https://github.com/SagerNet/sing-box/releases/tag/v${{ needs.prepare.outputs.upstream }})，上游版本的完整更新说明见对应 Release。"
             echo ""
             echo "- \`*.tar.gz\`：压缩包内含单个 \`sing-box\` 二进制"
             echo "- \`*.upx\`：经 UPX (--best --lzma) 压缩的裸二进制，下载后 \`chmod +x\` 即可直接使用"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,211 @@
+name: 构建并发布 ShellCrash 内核 (sing-box-lx)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '要构建的版本 tag（如 v1.13.13-lx.3）；留空则自动使用仓库最新 semver tag'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sing-box-lx-release-${{ inputs.version || 'auto-latest' }}
+  cancel-in-progress: false
+
+jobs:
+  # ============================================================
+  # 阶段一：解析版本号与构建标签
+  # ============================================================
+  prepare:
+    name: 解析版本与构建标签
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      tags: ${{ steps.tags.outputs.tags }}
+    steps:
+      - name: 检出仓库（拉取全部 tag）
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: 解析版本号并切换到对应 tag
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          INPUT_VERSION='${{ inputs.version }}'
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+            if ! git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+              echo "::error::指定的 tag $VERSION 在仓库中不存在"
+              exit 1
+            fi
+          else
+            VERSION=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -n1)
+            if [ -z "$VERSION" ]; then
+              echo "::error::仓库中没有任何 v 开头的 semver tag"
+              exit 1
+            fi
+          fi
+          echo "本次构建版本: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          git checkout --detach "refs/tags/$VERSION"
+
+      - name: 从 Makefile.lx 解析 TAGS 并过滤保留 6 个标签
+        id: tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          KEEP="with_quic with_utls with_clash_api with_xhttp badlinkname tfogo_checklinkname0"
+
+          # 优先用 make 本身展开 TAGS（可正确处理 := ?= += 及变量引用）
+          RAW=$(make -f Makefile.lx --no-print-directory -s \
+                --eval='print-tags: ; @echo $(TAGS)' print-tags 2>/dev/null || true)
+
+          # 回退：用 grep/sed 直接解析 TAGS 定义行
+          if [ -z "${RAW// /}" ]; then
+            RAW=$(grep -E '^[[:space:]]*TAGS[[:space:]]*[:?+]?=' Makefile.lx | head -n1 \
+                  | sed -E 's/^[[:space:]]*TAGS[[:space:]]*[:?+]?=[[:space:]]*//')
+          fi
+          echo "Makefile.lx 原始 TAGS: $RAW"
+
+          # 逗号/空格统一为换行后，按保留清单逐一过滤（保持清单顺序）
+          TAGS=""
+          for t in $KEEP; do
+            if printf '%s\n' $RAW | tr ',' '\n' | grep -Fxq "$t"; then
+              TAGS="${TAGS:+$TAGS,}$t"
+            fi
+          done
+          if [ -z "$TAGS" ]; then
+            echo "::error::过滤后 TAGS 为空，请检查 Makefile.lx 中的 TAGS 定义"
+            exit 1
+          fi
+          echo "过滤后 TAGS: $TAGS"
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+  # ============================================================
+  # 阶段二：矩阵构建并打包
+  # ============================================================
+  build:
+    name: 构建 linux/${{ matrix.arch }}
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            goarm: ''
+            arch: amd64
+            upx: false
+          - goos: linux
+            goarch: arm
+            goarm: '7'
+            arch: armv7
+            upx: true
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
+      TAGS: ${{ needs.prepare.outputs.tags }}
+    steps:
+      - name: 检出 tag ${{ needs.prepare.outputs.version }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.version }}
+          fetch-depth: 0
+
+      - name: 安装 Go（版本读取自 go.mod）
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: 编译 sing-box（GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }}）
+        shell: bash
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          GOARM: ${{ matrix.goarm }}
+          CGO_ENABLED: '0'
+        run: |
+          set -euo pipefail
+          go build -v -trimpath -buildvcs=false -tags "$TAGS" \
+            -ldflags "-s -w -X github.com/sagernet/sing-box/constant.Version=$VERSION" \
+            -o sing-box ./cmd/sing-box
+          ls -lh sing-box
+
+      - name: 打包普通 tar.gz
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p stage dist
+          cp sing-box stage/sing-box
+          tar -czf "dist/sing-box-${VERSION}-linux-${{ matrix.arch }}.tar.gz" -C stage sing-box
+          rm -f stage/sing-box
+
+      - name: UPX 压缩二进制
+        if: matrix.upx
+        shell: bash
+        run: |
+          set -euo pipefail
+          upx --best --lzma sing-box
+          ls -lh sing-box
+          mkdir -p dist
+          cp sing-box "dist/sing-box-${VERSION}-linux-${{ matrix.arch }}-upx"
+
+      - name: 上传构建产物到工件
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-linux-${{ matrix.arch }}
+          path: dist/*
+          if-no-files-found: error
+
+  # ============================================================
+  # 阶段三：汇总产物并发布 Release
+  # ============================================================
+  release:
+    name: 创建 GitHub Release
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: 下载全部构建工件
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          path: dist
+          merge-multiple: true
+
+      - name: 生成 SHA256SUMS 与 Release 正文
+        shell: bash
+        working-directory: dist
+        run: |
+          set -euo pipefail
+          sha256sum sing-box-* | tee SHA256SUMS
+          {
+            echo "sing-box-lx ${{ needs.prepare.outputs.version }} 自动构建。"
+            echo ""
+            echo "- \`*.tar.gz\`：压缩包内含单个 \`sing-box\` 二进制"
+            echo "- \`*-upx\`：经 UPX (--best --lzma) 压缩的裸二进制，下载后 \`chmod +x\` 即可直接使用"
+            echo ""
+            echo "构建标签：\`${{ needs.prepare.outputs.tags }}\`"
+            echo ""
+            echo "## 文件 SHA256"
+            echo '```'
+            cat SHA256SUMS
+            echo '```'
+          } > body.md
+
+      - name: 发布 Release（tag: ${{ needs.prepare.outputs.version }}）
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.version }}
+          name: sing-box-lx ${{ needs.prepare.outputs.version }} for ShellCrash
+          body_path: dist/body.md
+          files: |
+            dist/*.tar.gz
+            dist/sing-box-*-upx
+            dist/SHA256SUMS

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -55,30 +55,23 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           git checkout --detach "refs/tags/$VERSION"
 
-      - name: 从 Makefile.lx 解析 TAGS 并过滤保留 6 个标签
+      - name: 从 Makefile.lx 解析 LX_TAGS 并过滤保留 6 个标签
         id: tags
         shell: bash
         run: |
           set -euo pipefail
           KEEP="with_quic with_utls with_clash_api with_xhttp badlinkname tfogo_checklinkname0"
 
-          # 若检出的 tag 上没有 Makefile.lx，回退使用 lx 分支上的版本
-          if [ ! -f Makefile.lx ]; then
-            echo "::warning::当前 tag 上不存在 Makefile.lx，改用 lx 分支的 Makefile.lx"
-            git show origin/lx:Makefile.lx > Makefile.lx
-          fi
+          # Makefile.lx 的变量名是 LX_TAGS，且自带 lx-print-tags 目标
+          # （其注释明确写明供 CI/release 使用，避免重复维护标签集）
+          RAW=$(make -f Makefile.lx --no-print-directory -s lx-print-tags 2>/dev/null || true)
 
-          # 优先用 make 本身展开 TAGS（兼容 := ?= += 及变量引用）
-          RAW=$(make -f Makefile.lx --no-print-directory -s \
-                --eval='print-tags: ; @echo $(TAGS)' print-tags 2>/dev/null || true)
-
-          # 回退：用 grep/sed 解析 TAGS 定义行（兼容 export/override 前缀）
-          # 注意结尾的 || true：防止 grep 未命中时管道非零退出被 set -e 终止
+          # 回退：用 grep/sed 直接解析 LX_TAGS 定义行
           if [ -z "${RAW// /}" ]; then
-            RAW=$(grep -E '^[[:space:]]*(export[[:space:]]+)?(override[[:space:]]+)?TAGS[[:space:]]*[:?+]?=' Makefile.lx | head -n1 \
-                  | sed -E 's/^[[:space:]]*(export[[:space:]]+)?(override[[:space:]]+)?TAGS[[:space:]]*[:?+]?=[[:space:]]*//' || true)
+            RAW=$(grep -E '^[[:space:]]*LX_TAGS[[:space:]]*[:?+]?=' Makefile.lx | head -n1 \
+              | sed -E 's/^[[:space:]]*LX_TAGS[[:space:]]*[:?+]?=[[:space:]]*//')
           fi
-          echo "Makefile.lx 原始 TAGS: '$RAW'"
+          echo "Makefile.lx 原始 LX_TAGS: $RAW"
 
           # 逗号/空格统一为换行后，按保留清单逐一过滤（保持清单顺序）
           TAGS=""
@@ -88,8 +81,7 @@ jobs:
             fi
           done
           if [ -z "$TAGS" ]; then
-            echo "::error::过滤后 TAGS 为空。Makefile.lx 中 TAGS 相关行如下："
-            grep -n 'TAGS' Makefile.lx || true
+            echo "::error::过滤后 TAGS 为空，请检查 Makefile.lx 中的 LX_TAGS 定义"
             exit 1
           fi
           echo "过滤后 TAGS: $TAGS"
@@ -126,7 +118,7 @@ jobs:
           ref: ${{ needs.prepare.outputs.version }}
           fetch-depth: 0
 
-      - name: 安装 Go（版本读取自 go.mod）
+      - name: 安装 Go
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
@@ -141,12 +133,15 @@ jobs:
           CGO_ENABLED: '0'
         run: |
           set -euo pipefail
+          # Makefile.lx 明确要求：badlinkname/tfogo_checklinkname0 需要 -checklinkname=0，
+          # 否则 Go 1.24+ 的链接器会拒绝 badtls 对 crypto/tls 的 go:linkname。
+          # ${VERSION#v} 去掉 tag 的 v 前缀，与 Makefile.lx 的 LX_VERSION 形式（如 1.13.13-lx.1）一致。
           go build -v -trimpath -buildvcs=false -tags "$TAGS" \
-            -ldflags "-s -w -X github.com/sagernet/sing-box/constant.Version=$VERSION" \
+            -ldflags "-s -w -checklinkname=0 -X github.com/sagernet/sing-box/constant.Version=${VERSION#v}" \
             -o sing-box ./cmd/sing-box
           ls -lh sing-box
 
-      - name: 打包普通 tar.gz（内部仅含 sing-box 二进制）
+      - name: 打包普通 tar.gz
         shell: bash
         run: |
           set -euo pipefail
@@ -193,6 +188,7 @@ jobs:
         run: |
           set -euo pipefail
           sha256sum sing-box-* | tee SHA256SUMS
+
           {
             echo "sing-box-lx ${{ needs.prepare.outputs.version }} 自动构建。"
             echo ""

--- a/.github/workflows/sync-upstream-release.yml
+++ b/.github/workflows/sync-upstream-release.yml
@@ -1,0 +1,82 @@
+name: Sync upstream release
+
+on:
+  schedule:
+    - cron: "23 1 * * *"   # 每天检查一次(UTC 01:23,东京时间 10:23)
+  workflow_dispatch:          # 支持手动触发
+
+permissions:
+  contents: write
+
+env:
+  UPSTREAM_REPO: Leadaxe/sing-box-lx
+  SYNC_BRANCH: lx
+
+jobs:
+  sync:
+    name: Sync on new upstream release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get upstream latest release tag
+        id: upstream
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag=$(gh api "repos/${UPSTREAM_REPO}/releases/latest" --jq .tag_name)
+          echo "Upstream latest release: ${tag}"
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check if fork already has this tag
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.upstream.outputs.tag }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG}" --silent; then
+            echo "Tag ${TAG} already exists in fork, nothing to do."
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "New version ${TAG} detected."
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Checkout fork
+        if: steps.check.outputs.exists == 'false'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SYNC_BRANCH }}
+          fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Merge upstream tag into fork branch
+        if: steps.check.outputs.exists == 'false'
+        env:
+          TAG: ${{ steps.upstream.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote add upstream "https://github.com/${UPSTREAM_REPO}.git"
+          git fetch upstream --tags
+          git fetch origin "${SYNC_BRANCH}"
+          git checkout -B "${SYNC_BRANCH}" "origin/${SYNC_BRANCH}"
+          git merge --no-edit "${TAG}"
+
+      - name: Push branch and new tag
+        if: steps.check.outputs.exists == 'false'
+        env:
+          TAG: ${{ steps.upstream.outputs.tag }}
+        run: |
+          git push origin "${SYNC_BRANCH}"
+          git push origin "refs/tags/${TAG}"
+
+      - name: Mirror the release notes in fork
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.upstream.outputs.tag }}
+        run: |
+          notes=$(gh api "repos/${UPSTREAM_REPO}/releases/tags/${TAG}" --jq .body)
+          gh release create "${TAG}" \
+            --repo "${{ github.repository }}" \
+            --title "${TAG}" \
+            --notes "${notes}"


### PR DESCRIPTION
This pull request adds two new GitHub Actions workflows to automate the build, release, and upstream synchronization processes for the project. The first workflow handles building and releasing project artifacts for multiple architectures, and the second workflow automatically syncs new releases from the upstream repository into the fork. The key changes are as follows:

**Build and Release Automation:**

* Introduced `.github/workflows/build-release.yml` to automate building, packaging, and releasing the `sing-box-lx` kernel for different Linux architectures. The workflow includes version/tag parsing, matrix builds (amd64 and armv7), artifact packaging (tar.gz and UPX-compressed binaries), and automated GitHub Release creation with generated release notes.

**Upstream Synchronization:**

* Added `.github/workflows/sync-upstream-release.yml` to periodically (daily) and manually check for new releases in the upstream repository (`Leadaxe/sing-box-lx`). When a new tag is detected, the workflow merges the upstream tag into the fork's `lx` branch, pushes the changes, and mirrors the upstream release notes into a new GitHub Release in the fork.